### PR TITLE
add icml-21 recsys paper list

### DIFF
--- a/aaai_20.md
+++ b/aaai_20.md
@@ -1,7 +1,4 @@
-# AAAI‐20
-
-## ***Paper List of Recommendation System***
-
+# RecSys-Papers-from-AAAI‐2020
 ### (27 RecSys / 1590 Acceptance)
 
 |Num |Title| 

--- a/aaai_21.md
+++ b/aaai_21.md
@@ -1,8 +1,4 @@
-
-# AAAI‐21
-
-## ***Paper List of Recommendation System***
-
+# RecSys-Papers-from-AAAI‐2021
 ### (33 RecSys / 1696 Acceptance)
 
 ```Note: 70.6% of accepted papers are student papers.```

--- a/icml_21.md
+++ b/icml_21.md
@@ -1,0 +1,13 @@
+# RecSys-Papers-from-ICML-2021
+
+## Learning Self-Modulating Attention in Continuous Time Space with Applications to Sequential Recommendation
+> Chao Chen (Shanghai Jiao Tong University) · Haoyu Geng (Shanghai Jiao Tong University) · Nianzu Yang (Shanghai Jiao Tong University) · Junchi Yan (Shanghai Jiao Tong University) · Daiyue Xue (Meituan) · Jianping Yu (Meituan) · Xiaokang Yang (Shanghai Jiao Tong University of China)
+
+## Quantifying Availability and Discovery in Recommender Systems via Stochastic Reachability 
+> Mihaela Curmei (Berkeley) · Sarah Dean (UC Berkeley) · Benjamin Recht (Berkeley)
+
+## Correcting Exposure Bias for Link Recommendation
+> Shantanu Gupta (Carnegie Mellon University) · Hao Wang (Rutgers University) · Zachary Lipton (Carnegie Mellon University) · Yuyang Wang (AWS AI Labs)
+
+## Meta Latents Learning for Open-World Recommender Systems
+> Qitian Wu (Shanghai Jiao Tong University) · Hengrui Zhang (University of Illinois at Chicago) · Xiaofeng Gao (Shanghai Jiaotong University) · Junchi Yan (Shanghai Jiao Tong University) · Hongyuan Zha (Shenzhen Institute of Artificial Intelligence and Robotics for Society; The Chinese University of Hong Kong, Shenzhen)

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
 
 # New
 
+* [[Selected papers in ICML2021]](icml_21.md)
 * [[Selected papers in AAAI2021]](aaai_21.md)
 * [[Selected papers in WSDM2021]](wsdm_21.md)
 * [[Selected papers in WWW2021]](www_21.md)


### PR DESCRIPTION
Select RecSys related papers from ICML 2021 accepted papers list: https://icml.cc/Conferences/2021/AcceptedPapersInitial.